### PR TITLE
Load YT after function definition

### DIFF
--- a/lecture/templates/lecture.html
+++ b/lecture/templates/lecture.html
@@ -85,7 +85,6 @@
             background-color: lightblue;
         }
     </style>
-    <script src="https://www.youtube.com/iframe_api"></script>
 </head>
 <body>
     <div id="player-container">
@@ -251,5 +250,6 @@
         document.addEventListener("visibilitychange", () => telemetry("document-visibility-change"));
         document.addEventListener("fullscreenchange", () => telemetry("fullscreen-change"));
     </script>
+    <script src="https://www.youtube.com/iframe_api"></script>
 </body>
 </html>


### PR DESCRIPTION
The PR attempts to resolve an issue with lectures not loading their iframes.

Moved the YT iframe API import to happen after we define onYoutubeIframeAPIReady(). This ensures that the async loading that the iframe API does will not fire the ready event before we have defined our function.